### PR TITLE
Return `gb18030` instead of `gbk`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@ use pyo3::prelude::*;
 // https://docs.python.org/3/library/codecs.html#standard-encodings
 // https://encoding.spec.whatwg.org/#legacy-single-byte-encodings
 fn _fix_encoding_name(encoding: &str) -> &str {
-    match encoding {
+    match encoding.to_lowercase().as_str() {
         "windows-874" => "cp874",
-        "GBK" => "gb18030",
+        "gbk" => "gb18030",
         _ => encoding
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@ use pyo3::prelude::*;
 // https://docs.python.org/3/library/codecs.html#standard-encodings
 // https://encoding.spec.whatwg.org/#legacy-single-byte-encodings
 fn _fix_encoding_name(encoding: &str) -> &str {
-    if encoding == "windows-874" {
-        "cp874"
-    } else {
-        encoding
+    match encoding {
+        "windows-874" => "cp874",
+        "GBK" => "gb18030",
+        _ => encoding
     }
 }
 

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,7 +1,22 @@
 """Test cases for the chardetng_py module."""
-from chardetng_py import decode
+import pytest
+from chardetng_py import detect
 
 
 def test_decode() -> None:
     """Very basic decode litmus test."""
-    assert decode(b"Jakby r\xeaka Boga") == "Jakby rêka Boga"
+    raw = b"Jakby r\xeaka Boga"
+    assert raw.decode(detect(raw)) == "Jakby rêka Boga"
+
+
+@pytest.mark.parametrize(("text", "encoding", "detected_encoding"), [
+    ("สวัสดี, โลก", "cp874", "cp874"),
+    ("员会 ⛆", "gb18030", "gb18030"),
+])
+def test_returns_python_supported_names(
+    text: str,
+    encoding: str,
+    detected_encoding: str,
+) -> None:
+    """Ensure detection returns encoding names that are supported in Python."""
+    assert detect(text.encode(encoding)) == detected_encoding


### PR DESCRIPTION
Chardetng doesn't differentiate between 'gbk' and 'gb18030' because it is designed to work with encoding_rs, which *decodes* [both of them the same](https://docs.rs/encoding_rs/latest/encoding_rs/static.GBK.html) (gb18030 is a superset of gbk, which is a superset of gb2312 — [WHATWG specifies browsers should decode them all as gb18030](https://encoding.spec.whatwg.org/#gbk-decoder) in order to be maximally compatible with content on the web). However, Python's built-in decoders are more strict, and do not decode the two the same way.

That means that, if `chardetng_py` tells you some bytes are `gbk`, they might not work with Python’s decoder. In other words, this will throw:

```py
chinese_bytes = '员会 ⛆'.encode('gb18030')
chardetng_py.detect(chinese_bytes)
# 'GBK'
chinese_bytes.decode('GBK')
# Raises UnicodeDecodeError: 'gbk' codec can't decode byte 0x81 in position 5: illegal multibyte sequence
chinese_bytes.decode('GB18030')
# '员会 ⛆'
```

I missed this subtlety in my research on #11, where I was mostly focusing on the single-byte encodings.

If we switch this around users won't need to worry about the issue. I think this is fairly safe, too — the only reason you'd want to decode a string with the `gbk` decoder in Python instead of the `gb18030` decoder is if you really expect that it should be `gbk`, and could be either dangerous or corrupted if decoding doesn’t work. But if you are using Chardetng to sniff the encoding, you don't generally have any expectations like that.

(Wikipedia also has a good summary on the history and relationships of these encodings in its article on GB 18030: https://en.wikipedia.org/wiki/GB_18030)

---

As a side note, the current tests didn’t seem to work (I fixed those), and and `CONTRIBUTING.md` instructions also seem broken (Nox can’t find `noxfile.py` and nox doesn’t get any other mentions elsewhere in the source, so I suspect the doc is just out of date, or was autogenerated and never accurate). I ran these by doing `poetry run maturin develop; poetry run pytest`.